### PR TITLE
Use itemstack with count of 1 for Item URL grabbing

### DIFF
--- a/forge16/src/main/java/com/envyful/gts/forge/config/EnvyGTSConfig.java
+++ b/forge16/src/main/java/com/envyful/gts/forge/config/EnvyGTSConfig.java
@@ -230,13 +230,15 @@ public class EnvyGTSConfig extends AbstractYamlConfig {
     }
 
     public String getItemUrl(ItemStack itemStack) {
-        String format = this.getFormat(itemStack);
+        ItemStack isnocount = itemStack.copy();
+        isnocount.setCount(1);
+        String format = this.getFormat(isnocount);
 
         if (format != null) {
             return format;
         }
 
-        return this.itemUrlFormats.getOrDefault(itemStack.getItem().getRegistryName().getNamespace(), this.fallback);
+        return this.itemUrlFormats.getOrDefault(isnocount.getItem().getRegistryName().getNamespace(), this.fallback);
     }
 
     private String getFormat(ItemStack itemStack) {


### PR DESCRIPTION
Workaround for jsonified/NBT item replacement URLs taking count/item quantity into consideration, when it should be ignored
Just set your jsonified itemstack in `item-replacement-u-r-ls` to `Count:1b`.

Ex.: 
```
item-replacement-u-r-ls:
    '{id:"pixelmon:poke_ball",Count:1b,tag:{PokeBallID:"master_ball"}}': https://pixelmonmod.com/wiki/Special:Redirect/file/Grid_Master_Ball.png
```